### PR TITLE
[DEV-874] selective throttling

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,9 +5,9 @@ can access a resource. Going over this rate will return an error response.
 
 ## Usage
 
-Dependency via [clojars](https://clojars.org/compojure-throttle)
+Internal artifactory
 
-    [compojure-throttle "0.1.7"]
+    [compojure-throttle "0.1.8"]
 
 Then use with 
 
@@ -38,8 +38,8 @@ unique user id and that we want to throttle based on this.
 
 To configure the rate at which we throttle use two environment variables:
 
-    COMPOJURE_THROTTLE_TTL=1000
-    COMPOJURE_THROTTLE_TOKENS=3
+    SERVICE_COMPOJURE_THROTTLE_TTL=1000
+    SERVICE_COMPOJURE_THROTTLE_TOKENS=3
 
 TTL defines the period for which we are throttling e.g. 1000 milliseconds
 TOKENS defines the number of tries a user is allowed within that period.
@@ -50,7 +50,12 @@ throttling whilst still throttling sustained high traffic.
 
 We can also configure the response code for throttled requests using:
 
-    COMPOJURE_THROTTLE_RESPONSE_CODE=420
+    SERVICE_COMPOJURE_THROTTLE_RESPONSE_CODE=420
+    
+To disable throttling set:
+   
+    SERVICE_COMPOJURE_THROTTLE_ENABLED=false
+    SERVICE_COMPOJURE_THROTTLE_LAX_IPS="subnet for disabling throttling" 
 
 # Building #
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject compojure-throttle "0.1.8-SNAPSHOT"
+(defproject compojure-throttle "0.1.8"
 
   :description "Throttling middleware for compojure"
 

--- a/project.clj
+++ b/project.clj
@@ -7,9 +7,10 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
             
-  :dependencies [[org.clojure/clojure "1.7.0"]
+  :dependencies [[clj-time "0.11.0"]
+                 [functionalbytes/clj-ip "0.9.0"]
+                 [org.clojure/clojure "1.7.0"]
                  [org.clojure/core.cache "0.6.4"]
-                 [clj-time "0.11.0"]
                  [environ "1.0.1"]]
 
   :lein-release {:deploy-via :clojars}

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -71,6 +71,11 @@
 
 (defn throttle
   "Throttle incoming connections from a given source. By default this is based on IP.
+
+   Throttling is controlled by both :service-compojure-throttle-enabled and 
+   :service-compojure-throttle-lax-ips. If
+   :service-compojure-throttle-enabled is false, throttling will still happen 
+   to any IP not covered by :service-compojure-throttle-lax-ips.
   
   Optionally takes a second argument which is a function used to lookup the 'token'
   that determines whether or not the request is unique. For example a function that

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -1,5 +1,5 @@
 (ns compojure-throttle.core
-  (:require [clj.ip :refer [compile]]
+  (:require [clj.ip :as ip]
             [clj-time.core :as core-time]
             [clj-time.local :as local-time]
             [clojure.core.cache :as cache]
@@ -18,12 +18,12 @@
              (or (env :service-compojure-throttle-enabled)
                  (defaults :service-compojure-throttle-enabled)))))
 
-(defn- ip-subnet
+(defn- ip-lax-subnet
   []
   (or (env :service-compojure-throttle-lax-ips)
       (defaults :service-compojure-throttle-lax-ips)))
 
-(def in-subnet? (compile (ip-subnet)))
+(def in-lax-subnet? (ip/compile (ip-lax-subnet)))
 
 (defn- prop
   [key]
@@ -79,7 +79,7 @@
   ([finder handler]
    (fn [req]
      (if (and (or (enabled?)
-                  (not (in-subnet? (:remote-addr req))))
+                  (not (in-lax-subnet? (:remote-addr req))))
               (throttle? (finder req)))
        {:status (prop :service-compojure-throttle-response-code)
         :body   "You have sent too many requests. Please wait before retrying."}


### PR DESCRIPTION
Disabling the throttler now requires a valid subnet (`:service-compojure-throttle-lax-ips`) to be specified in addition to setting the `:service-compojure-throttle-enabled` flag to false.

Otherwise, the default behavior to disable the throttling will only disable it for `127.0.0.1`

(also removed the snapshot from the version #)
