### PR TITLE
[DEV-10250] Add custom throttle cache for more configurability

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,32 @@ We can also configure the response code for throttled requests using:
 To disable throttling set:
 
     SERVICE_COMPOJURE_THROTTLE_LAX_IPS="subnet for disabling throttling" 
+    
+These settings are applied globally across all caches (see below).
+    
+## Even More Configurability
+
+For full generality, you can create your own throttler-cache with custom TTL
+and token settings, and pass it as a third argument to `throttle`. This allows 
+you to have different TTL and token settings for different requests.
+
+For example:
+
+```
+(defroutes main-routes
+
+  ;; One request every 500ms, by :user
+  (throttler/throttle
+    :user
+    (throttler/make-throttle-cache {:ttl 500 :tokens 1})
+    (POST "/data" req "OK"))
+
+  ;; Three requests every 2000ms, by IP
+  (throttler/throttle
+    throttler/by-ip
+    (throttler/make-throttle-cache {:ttl 2000 :tokens 3})
+    (POST "/data" req "OK")))
+```
 
 # Building #
 

--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject compojure-throttle "0.1.8"
+(defproject compojure-throttle "0.1.9"
 
   :description "Throttling middleware for compojure"
 
@@ -9,14 +9,14 @@
 
   :dependencies [[clj-time "0.11.0"]
                  [functionalbytes/clj-ip "0.9.0"]
-                 [org.clojure/clojure "1.7.0"]
-                 [org.clojure/core.cache "0.6.4"]
+                 [org.clojure/clojure "1.10.1"]
+                 [org.clojure/core.cache "1.0.207"]
                  [environ "1.0.1"]]
 
   :lein-release {:deploy-via :clojars}
 
-  :profiles {:dev  {:dependencies [[midje "1.8.2"]]
-                    :plugins      [[lein-midje "2.0.0-SNAPSHOT"]
+  :profiles {:dev  {:dependencies [[midje "1.9.9"]]
+                    :plugins      [[lein-midje "3.2.1"]
                                    [lein-release "1.0.5"]
                                    [lein-environ "1.1.0"]]
                     :env          {:service-compojure-throttle-lax-ips "127.0.0.1/32"}}})

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -109,4 +109,4 @@
   ([finder handler]
    (throttle finder requests handler))
   ([handler]
-   (throttle by-ip requests handler)))
+   (throttle by-ip handler)))

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -25,22 +25,32 @@
   (Integer. (or (env key)
                 (defaults key))))
 
+(defn make-throttle-cache
+  "Initialize a throttling cache with a given TTL and tokens.
+
+   Pass a map containing keys :ttl and :tokens.
+
+   This maintains all of the state for figuring out which request to throttle.
+   (Yeah, it's just a TTL cache, but don't rely on that.)"
+  [{:keys [ttl tokens]}]
+  {:cache          (atom (cache/ttl-cache-factory {} :ttl ttl))
+   :ttl-setting    ttl
+   :tokens-setting tokens})
+
 (def ^:private requests
-  (atom (cache/ttl-cache-factory {} :ttl (prop :service-compojure-throttle-ttl))))
+  "Default cache for throttling requests globally."
+  (make-throttle-cache {:ttl    (prop :service-compojure-throttle-ttl)
+                        :tokens (prop :service-compojure-throttle-tokens)}))
 
 (defn reset-cache
-  "Testing helper that resets the content of the cache - should allow tests to run from a known base"
+  "Testing helper that resets the content of the global cache - should allow
+   tests to run from a known base"
   []
-  (reset! requests (cache/ttl-cache-factory {} :ttl (prop :service-compojure-throttle-ttl))))
+  (reset! (:cache requests) (cache/ttl-cache-factory {} :ttl (:ttl-setting requests))))
 
 (defn- update-cache
-  [id tokens]
-  (swap! requests cache/miss id tokens))
-
-(defn token-period
-  []
-  (/ (prop :service-compojure-throttle-ttl)
-     (prop :service-compojure-throttle-tokens)))
+  [cache id tokens]
+  (swap! cache cache/miss id tokens))
 
 (defn- record
   [tokens]
@@ -48,19 +58,22 @@
    :datetime (local-time/local-now)})
 
 (defn- throttle?
-  [id]
-  (when-not (cache/has? @requests id)
-    (update-cache id (record (prop :service-compojure-throttle-tokens))))
-  (let [entry     (cache/lookup @requests id)
+  [{:keys [cache ttl-setting tokens-setting]} id]
+  (when-not (cache/has? @cache id)
+    (update-cache cache id (record tokens-setting)))
+  (let [entry     (cache/lookup @cache id)
         spares    (int (/ (core-time/in-millis (core-time/interval
                                                  (:datetime entry)
                                                  (local-time/local-now)))
-                          (token-period)))
+                          (/ ttl-setting tokens-setting)))
         remaining (+ (:tokens entry) spares)]
-    (update-cache id (record (dec remaining)))
+    (update-cache cache id (record (dec remaining)))
     (not (pos? remaining))))
 
-(defn- by-ip
+(defn by-ip
+  "A finder function that gets the IP from the request.
+
+   This is used by default for `throttle` when no function is provided."
   [req]
   (:remote-addr req))
 
@@ -72,17 +85,23 @@
    :service-compojure-throttle-enabled is false, throttling will still happen 
    to any IP not covered by :service-compojure-throttle-lax-ips.
   
-  Optionally takes a second argument which is a function used to lookup the 'token'
-  that determines whether or not the request is unique. For example a function that
-  returns a user token to limit by user id rather than ip. This function should accept
-  the request as its single argument"
-  ([finder handler]
+   Optionally takes a second argument which is a function used to lookup the 'token'
+   that determines whether or not the request is unique. For example a function that
+   returns a user token to limit by user id rather than ip. This function should accept
+   the request as its single argument.
+
+   For full generality, this also takes an optional third argument, an instance
+   of 'throttle-cache'. Create one using (make-throttle-cache ttl tokens) to
+   have a separate throttler from the global one with custom settings."
+  ([finder throttle-cache handler]
    (fn [req]
      (if (and (or (nil? (ip-lax-subnet))
                   (not (in-lax-subnet? (:remote-addr req))))
-              (throttle? (finder req)))
+              (throttle? throttle-cache (finder req)))
        {:status (prop :service-compojure-throttle-response-code)
         :body   "You have sent too many requests. Please wait before retrying."}
        (handler req))))
+  ([finder handler]
+   (throttle finder requests handler))
   ([handler]
-   (throttle by-ip handler)))
+   (throttle by-ip requests handler)))

--- a/src/compojure_throttle/core.clj
+++ b/src/compojure_throttle/core.clj
@@ -37,6 +37,11 @@
    :ttl-setting    ttl
    :tokens-setting tokens})
 
+(defn reset-throttle-cache!
+  "Testing helper that resets given throttling cache, to allow for tests to run reliably."
+  [{:keys [cache ttl-setting]}]
+  (reset! cache (cache/ttl-cache-factory {} :ttl ttl-setting)))
+
 (def ^:private requests
   "Default cache for throttling requests globally."
   (make-throttle-cache {:ttl    (prop :service-compojure-throttle-ttl)
@@ -46,7 +51,7 @@
   "Testing helper that resets the content of the global cache - should allow
    tests to run from a known base"
   []
-  (reset! (:cache requests) (cache/ttl-cache-factory {} :ttl (:ttl-setting requests))))
+  (reset-throttle-cache! requests))
 
 (defn- update-cache
   [cache id tokens]

--- a/test/compojure_throttle/core_test.clj
+++ b/test/compojure_throttle/core_test.clj
@@ -15,8 +15,7 @@
 
               (fact "Multiple calls do get throttled"
                     (dotimes [x 3]
-                      (ok-or-throttle {:remote-addr "10.0.0.2"}) => (contains {:status 200})
-                      (provided (token-period) => 100000))
+                      (ok-or-throttle {:remote-addr "10.0.0.2"}) => (contains {:status 200}))
                     (ok-or-throttle {:remote-addr "10.0.0.2"}) => (contains {:status 429}))
 
               (fact "The bucket refills"
@@ -39,4 +38,14 @@
               (fact "Reset cache resets the cache"
                     (dotimes [x 10]
                       (reset-cache)
-                      (ok-or-throttle {:remote-addr "10.0.0.4"}) => (contains {:status 200}))))) 
+                      (ok-or-throttle {:remote-addr "10.0.0.4"}) => (contains {:status 200}))))
+            (let [local-throttler (make-throttle-cache {:ttl 10000 :tokens 1})
+                  handler         (throttle :foobar local-throttler (constantly {:status 200}))
+                  req             {:foobar :baz :remote-addr "192.168.1.1"}]
+              (fact "Local throttle cache works"
+                    (dotimes [_ 10] (ok-or-throttle req)) ; Should not affect the other request
+                    (handler req) => (contains {:status 200})
+                    (handler req) => (contains {:status 429})
+                    (handler req) => (contains {:status 429})
+                    (handler req) => (contains {:status 429})
+                    (handler (assoc req :foobar :other)) => (contains {:status 200}))))

--- a/test/compojure_throttle/core_test.clj
+++ b/test/compojure_throttle/core_test.clj
@@ -48,4 +48,16 @@
                     (handler req) => (contains {:status 429})
                     (handler req) => (contains {:status 429})
                     (handler req) => (contains {:status 429})
-                    (handler (assoc req :foobar :other)) => (contains {:status 200}))))
+                    (handler (assoc req :foobar :other)) => (contains {:status 200}))
+              (fact "Reset local throttling cache resets the local cache"
+                    (reset-throttle-cache! local-throttler)
+                    ; Global throttler should not affect local throttling
+                    (dotimes [_ 10] (ok-or-throttle req))
+                    (handler req) => (contains {:status 200})
+                    (handler req) => (contains {:status 429})
+                    (handler req) => (contains {:status 429})
+
+                    (reset-throttle-cache! local-throttler)
+                    (handler req) => (contains {:status 200})
+                    (handler req) => (contains {:status 429})
+                    (handler req) => (contains {:status 429}))))


### PR DESCRIPTION
This change addresses DEV-10250 in our private JIRA: more configurable rate limiting. It does this by generalizing and exposing the throttling cache so that different throttlers can have independent caches with independent settings. For example, one might want to have more restrictive per-user throttling than per-IP throttling. The change allows for this:

```clojure
(defroutes main-routes
  ;; One request every 500ms, by :user
  (throttler/throttle
    :user
    (throttler/make-throttle-cache {:ttl 500 :tokens 1})
    (POST "/data" req "OK"))
  ;; Three requests every 2000ms, by IP
  (throttler/throttle
    throttler/by-ip
    (throttler/make-throttle-cache {:ttl 2000 :tokens 3})
    (POST "/data" req "OK")))
```

This PR also adds tests, bumps some dependencies and bumps the version number of this library to 0.1.9 (no breaking changes).





